### PR TITLE
Add extended balance RPC call

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -49,6 +49,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"listreceivedbyaccount", 2},
         {"getbalance", 1},
         {"getbalance", 2},
+        {"getextendedbalance", 0},
         {"getblockhash", 0},
         {"move", 2},
         {"move", 3},

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -396,6 +396,7 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "getaccount", &getaccount, true, false, true},
         {"wallet", "getaddressesbyaccount", &getaddressesbyaccount, true, false, true},
         {"wallet", "getbalance", &getbalance, false, false, true},
+        {"wallet", "getextendedbalance", &getextendedbalance, false, false, true},
         {"wallet", "getnewaddress", &getnewaddress, true, false, true},
         {"wallet", "getrawchangeaddress", &getrawchangeaddress, true, false, true},
         {"wallet", "getreceivedbyaccount", &getreceivedbyaccount, false, false, true},

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -220,6 +220,7 @@ extern UniValue signmessage(const UniValue& params, bool fHelp);
 extern UniValue getreceivedbyaddress(const UniValue& params, bool fHelp);
 extern UniValue getreceivedbyaccount(const UniValue& params, bool fHelp);
 extern UniValue getbalance(const UniValue& params, bool fHelp);
+extern UniValue getextendedbalance(const UniValue& params, bool fHelp);
 extern UniValue getunconfirmedbalance(const UniValue& params, bool fHelp);
 extern UniValue movecmd(const UniValue& params, bool fHelp);
 extern UniValue sendfrom(const UniValue& params, bool fHelp);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -711,6 +711,48 @@ UniValue getbalance(const UniValue& params, bool fHelp)
     return ValueFromAmount(nBalance);
 }
 
+UniValue getextendedbalance(const UniValue& params, bool fHelp)
+{
+    if (fHelp || (params.size() > 0))
+        throw runtime_error(
+            "getextendedbalance\n"
+            "\nGet extended balance information.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"blocks\": \"xxx\", (string) The current block height\n"
+            "  \"balance\": \"xxx\", (string) The total WGR balance\n"
+            "  \"balance_locked\": \"xxx\", (string) The locked WGR balance\n"
+            "  \"balance_unlocked\": \"xxx\", (string) The unlocked WGR balance\n"
+            "  \"balance_unconfirmed\": \"xxx\", (string) The unconfirmed WGR balance\n"
+            "  \"balance_immature\": \"xxx\", (string) The immature WGR balance\n"
+            "  \"zerocoin_balance\": \"xxx\", (string) The total zWGR balance\n"
+            "  \"zerocoin_balance_mature\": \"xxx\", (string) The mature zWGR balance\n"
+            "  \"zerocoin_balance_immature\": \"xxx\", (string) The immature zWGR balance\n"
+            "  \"watchonly_balance\": \"xxx\", (string) The total watch-only WGR balance\n"
+            "  \"watchonly_balance_unconfirmed\": \"xxx\", (string) The unconfirmed watch-only WGR balance\n"
+            "  \"watchonly_balance_immature\": \"xxx\", (string) The immature watch-only WGR balance\n"
+            "  \"watchonly_balance_locked\": \"xxx\", (string) The locked watch-only WGR balance\n"
+            "}\n"
+            "\nExamples:\n" +
+            HelpExampleCli("getextendedbalance", "") + HelpExampleRpc("getextendedbalance", ""));
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    UniValue obj(UniValue::VOBJ);
+    obj.push_back(Pair("blocks", (int)chainActive.Height()));
+    obj.push_back(Pair("balance", ValueFromAmount(pwalletMain->GetBalance())));
+    obj.push_back(Pair("balance_locked", ValueFromAmount(pwalletMain->GetLockedCoins())));
+    obj.push_back(Pair("balance_unlocked", ValueFromAmount(pwalletMain->GetUnlockedCoins())));
+    obj.push_back(Pair("balance_unconfirmed", ValueFromAmount(pwalletMain->GetUnconfirmedBalance())));
+    obj.push_back(Pair("balance_immature", ValueFromAmount(pwalletMain->GetImmatureBalance())));
+    obj.push_back(Pair("zerocoin_balance", ValueFromAmount(pwalletMain->GetZerocoinBalance(false))));
+    obj.push_back(Pair("zerocoin_balance_mature", ValueFromAmount(pwalletMain->GetZerocoinBalance(true))));
+    obj.push_back(Pair("zerocoin_balance_immature", ValueFromAmount(pwalletMain->GetImmatureZerocoinBalance())));
+    obj.push_back(Pair("watchonly_balance", ValueFromAmount(pwalletMain->GetWatchOnlyBalance())));
+    obj.push_back(Pair("watchonly_balance_unconfirmed", ValueFromAmount(pwalletMain->GetUnconfirmedWatchOnlyBalance())));
+    obj.push_back(Pair("watchonly_balance_immature", ValueFromAmount(pwalletMain->GetImmatureWatchOnlyBalance())));
+    obj.push_back(Pair("watchonly_balance_locked", ValueFromAmount(pwalletMain->GetLockedWatchOnlyBalance())));
+    return obj;
+}
+
 UniValue getunconfirmedbalance(const UniValue &params, bool fHelp)
 {
     if (fHelp || params.size() > 0)


### PR DESCRIPTION
Allows you to pull the following balances via RPC call:

- Available coins
- Immature coins
- Locked coins
- Total coins

