### PR TITLE
Update snapcraft

### DIFF
--- a/snap/gui/ion.desktop
+++ b/snap/gui/ion.desktop
@@ -2,7 +2,7 @@
 
 [Desktop Entry]
 Type=Application
-Version=3.1.99
+Version=3.0.5
 Encoding=UTF-8
 Name=Ion Qt
 Icon=${SNAP}/ion-qt.ico
@@ -10,5 +10,5 @@ MimeType=x-scheme-handler/ion;
 Exec=ion %u
 Terminal=false
 Categories=Office;Finance;Cryptocurrency;
-Comment=Ion Digital Currency QT (by CEVAP) CE source code (Community Edition)
+Comment=Ion Digital Currency QT (Official release)
 Keywords=internet;ion;main;qt;crypto;currency;snap;snapcraft;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,8 +9,9 @@ description: |
   transaction anonymity. This package include QT, daemon, cli and tx
   binaries.
   
-  Wiki (Ionomy):   https://github.com/ioncoincore/ion/wiki
-  Wiki (IonomyCE): https://github.com/ioncoincore/ion/wiki
+  Wiki (Ion Core):    https://github.com/ioncoincore/ion/wiki
+  Wiki (Ionomy):      https://github.com/ionomy/ion/wiki
+  Wiki (Ion Core CE): https://github.com/cevap/ion/wiki
   
   Technical documentaion: https://techdoc.ioncoin.org
   

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,9 +1,9 @@
 name: ioncore
-version: 3.1.99
+version: 3.0.5
 summary:   gaming related peer-to-peer network based digital currency
 description: |
   Ion Core is an MIT licensed,
-  open source, gaming oriented, blockchain-based cryptocurrency with 
+  open source, gaming oriented, blockchain-based cryptocurrency with
   ultra fast transactions, low fees, high network decentralization, and
   Zero Knowledge cryptography proofs for industry-leading
   transaction anonymity. This package include QT, daemon, cli and tx
@@ -31,7 +31,7 @@ description: |
     Reddit:    https://www.reddit.com/r/ionomy/
     Facebook:  https://facebook.com/ionomy
 
-grade: devel
+grade: stable
 confinement: strict
 
 apps:
@@ -56,7 +56,7 @@ parts:
   ion:
     source: https://github.com/ioncoincore/ion
     source-type: git
-    source-tag: master
+    source-tag: v3.0.5
     plugin: autotools
     # We don't want to copy the full blockchain every time that the snap is   
     # updated, but there's no way to define a default data dir in ion-qt.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,8 +2,8 @@ name: ioncore
 version: 3.1.99
 summary:   gaming related peer-to-peer network based digital currency
 description: |
-  ION is an MIT licensed,
-  open source, blockchain-based cryptocurrency with 
+  Ion Core is an MIT licensed,
+  open source, gaming oriented, blockchain-based cryptocurrency with 
   ultra fast transactions, low fees, high network decentralization, and
   Zero Knowledge cryptography proofs for industry-leading
   transaction anonymity. This package include QT, daemon, cli and tx
@@ -21,6 +21,7 @@ description: |
     https://github.com/ionomy/ion/wiki/ION-Technical-Whitepaper
   
   Get source code from Github: https://github.com/ioncoincore/ion.git
+  Get CE source code from Github: https://github.com/cevap/ion.git
   
   Chat with Support on Discord: https://discord.gg/vuZn7gC
   


### PR DESCRIPTION
Change wiki links to:
```
  Wiki (Ion Core):    https://github.com/ioncoincore/ion/wiki
  Wiki (Ionomy):      https://github.com/ionomy/ion/wiki
  Wiki (Ion Core CE): https://github.com/cevap/ion/wiki
```

and add `gaming related` into description
