### PR TITLE
snap: fix xenial build error, rename binutils-gold to binutils

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,7 +93,7 @@ parts:
       - libtool
       - bsdmainutils
       - g++-multilib 
-      - binutils-gold
+      - binutils
       - python3
     stage-packages: [ca-certificates]
     after:


### PR DESCRIPTION
should fix: https://build.snapcraft.io/user/ioncoincore/ion/443506