### PR TITLE
[maintenance][regtest][docs][wiki] chainparams, change regtest ports from testnets

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -389,6 +389,7 @@ public:
         pchMessageStart[1] = 0x9a;
         pchMessageStart[2] = 0x39;
         pchMessageStart[3] = 0x9e;
+        nDefaultPort = 34567;
         nSubsidyHalvingInterval = 150;
         nEnforceBlockUpgradeMajority = 4320; // 75%
         nRejectBlockOutdatedMajority = 5472; // 95%

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -53,6 +53,7 @@ public:
     CBaseRegTestParams()
     {
         networkID = CBaseChainParams::REGTEST;
+        nRPCPort = 28171;
         strDataDir = "regtest";
     }
 };


### PR DESCRIPTION
Set regtest port (nDefaultPort) to: `34567`
Set regtest rpc port (nRPCPort) to: `28171`