### PR TITLE
[Build system] debian, fix not met build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,6 @@ Build-Depends: debhelper,
  libdb4.8-dev,
  libdb4.8++-dev,
  libssl1.0-dev | libssl-dev,
- xvfb
  qtbase5-dev, qttools5-dev-tools, qttools5-dev,
  libgmp-dev,
  libqrencode-dev,
@@ -33,8 +32,7 @@ Build-Depends: debhelper,
  libzmq3-dev,
  locales-all,
  help2man,
- doxygen,
- dh-systemd
+ doxygen
 Standards-Version: 4.3.0
 Homepage: http://www.ionomy.com
 Vcs-Git: git://github.com/ioncoincore/ion.git


### PR DESCRIPTION
during the maintenance upgrade from sources, dh-systemd and xvfb were added
but they are not availble on bionic. Removing them should fix the issue.

removed build depends: xvfb, dh-systemd