### PR TITLE
Update circleci to not use snap subtree

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
         command: |
             apt-get -y update
             apt-get -y install python-pip
-            git clone --depth 1 https://bitbucket.org/ioncoin/ion .
+            git clone --depth 1 https://github.com/ioncoincore/ion .
             source .travis/lint_04_install.sh
             source .travis/lint_05_before_script.sh
             # LevelDB
@@ -26,12 +26,12 @@ jobs:
             # univalue
             git remote add -f univalue https://github.com/jgarzik/univalue
             # snap
-            git remote add -f snap  https://github.com/ioncoincore/ion
+            #git remote add -f snap  https://github.com/ioncoincore/ion
             git rm -rf src/leveldb
             git rm -rf src/secp256k1
             git rm -rf src/crypto/ctaes
             git rm -rf src/univalue
-            git rm -rf snap
+            #git rm -rf snap
             git add .
             git config --global user.email "lint@dev.null"
             git config --global user.name "Lint Check"
@@ -45,7 +45,7 @@ jobs:
             # univalue
             git subtree add --prefix src/univalue univalue 9f0b9975925b202ab130714e5422f8dd8bf40ac3 --squash
             # snap
-            git subtree add --prefix snap snap snap --squash
+            #git subtree add --prefix snap snap snap --squash
             source .travis/lint_06_script.sh
   x86_64_bionic:
     docker:

--- a/.travis/lint_04_install.sh
+++ b/.travis/lint_04_install.sh
@@ -6,9 +6,9 @@
 
 export LC_ALL=C
 
-pip install codespell==1.13.0
-pip install flake8==3.5.0
-pip install vulture==0.29
+pip2 install codespell==1.13.0
+pip2 install flake8==3.5.0
+pip2 install vulture==0.29
 
 SHELLCHECK_VERSION=v0.6.0
 curl -s "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/

--- a/.travis/lint_06_script.sh
+++ b/.travis/lint_06_script.sh
@@ -10,7 +10,7 @@ contrib/devtools/git-subtree-check.sh src/leveldb
 contrib/devtools/git-subtree-check.sh src/secp256k1
 contrib/devtools/git-subtree-check.sh src/crypto/ctaes
 contrib/devtools/git-subtree-check.sh src/univalue
-contrib/devtools/git-subtree-check.sh snap
+#contrib/devtools/git-subtree-check.sh snap
 
 # Fails with error 10 as not all commands are documented
 #contrib/devtools/check-doc.py


### PR DESCRIPTION
As there is no more snap subtree, the lint scripts are now ignoring that directory,  This can be revisited at a later date.